### PR TITLE
Drop leading `I` from generated decorator class names for interfaces starting with `I`+capital

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ public interface IMyService
 This will generate a decorator class that implements the interface and extends the LoggingDecorator.
 The attribute accepts multiple decorators.
 
+> Note: Generated decorator class names drop a leading `I` prefix when the interface name starts
+> with `I` followed by another capital letter (for example `IMyService` becomes
+> `MyServiceLoggingDecorator`). Interfaces like `IntrospectionService` keep the leading `I`.
+
 ## Partial implementations
 
 Decorators can be partially implemented by declaring a partial class that matches the generated
@@ -94,7 +98,7 @@ decorator so you can provide custom logic.
 ```cs
 namespace MyApp.Services
 {
-    public partial class IMyServiceLoggingDecorator
+    public partial class MyServiceLoggingDecorator
     {
         public int Add(int a, int b)
         {

--- a/example/Shroud.Example/Services/ExampleServiceLoggingDecorator.Partial.cs
+++ b/example/Shroud.Example/Services/ExampleServiceLoggingDecorator.Partial.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Shroud.Example.Services
 {
-    internal partial class IExampleServiceLoggingDecorator
+    internal partial class ExampleServiceLoggingDecorator
     {
         public decimal Divide(decimal a, decimal b)
         {

--- a/src/Shroud.Generator/DecoratorGenerator.cs
+++ b/src/Shroud.Generator/DecoratorGenerator.cs
@@ -86,7 +86,7 @@ namespace Shroud.Generator
                 var decoratorTypeName = tuple.Item2;
                 var compilation = tuple.Item3;
                 var registrationDecoratorTypes = tuple.Item4;
-                var interfaceName = CleanName(symbol.Name);
+                var interfaceName = CleanInterfaceName(symbol.Name);
                 var decoratorName = CleanName(decoratorTypeName);
                 var className = decoratorName.EndsWith("Decorator")
                     ? $"{interfaceName}{decoratorName}"
@@ -249,6 +249,22 @@ namespace Shroud.Generator
             var baseName = idx >= 0 ? name.Substring(0, idx) : name;
             var lastDot = baseName.LastIndexOf('.');
             return lastDot >= 0 ? baseName.Substring(lastDot + 1) : baseName;
+        }
+
+        private static string CleanInterfaceName(string name)
+        {
+            var cleaned = CleanName(name);
+            return StripLeadingInterfacePrefix(cleaned);
+        }
+
+        private static string StripLeadingInterfacePrefix(string name)
+        {
+            if (name.Length > 1 && name[0] == 'I' && char.IsUpper(name[1]))
+            {
+                return name.Substring(1);
+            }
+
+            return name;
         }
 
         private static List<string> GetDecoratorTypes(ISymbol symbol)

--- a/src/Shroud.Generator/ShroudExtensionGenerator.cs
+++ b/src/Shroud.Generator/ShroudExtensionGenerator.cs
@@ -64,7 +64,7 @@ namespace Shroud.Generator
                         continue;
                     }
                     var interfaceType = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-                    var interfaceTypeShort = symbol.Name;
+                    var interfaceTypeShort = StripLeadingInterfacePrefix(symbol.Name);
                     var interfaceNamespace = symbol.ContainingNamespace.ToDisplayString();
 
                     var decorators = new List<object>();
@@ -246,6 +246,16 @@ namespace Shroud.Generator
         {
             return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
                 .Replace("global::", string.Empty);
+        }
+
+        private static string StripLeadingInterfacePrefix(string name)
+        {
+            if (name.Length > 1 && name[0] == 'I' && char.IsUpper(name[1]))
+            {
+                return name.Substring(1);
+            }
+
+            return name;
         }
     }
 }

--- a/test/Shroud.Example.Tests/ExampleServiceTests.cs
+++ b/test/Shroud.Example.Tests/ExampleServiceTests.cs
@@ -106,17 +106,17 @@ public class ExampleServiceTests
         var service = provider.GetRequiredService<IExampleService>();
         var secondaryService = provider.GetRequiredService<ISecondaryService>();
 
-        Assert.IsType<IExampleServiceGlobalDecorator>(service);
-        Assert.IsType<ISecondaryServiceLoggingDecorator>(secondaryService);
+        Assert.IsType<ExampleServiceGlobalDecorator>(service);
+        Assert.IsType<SecondaryServiceLoggingDecorator>(secondaryService);
         var chain = GetDecoratorChain(service);
 
         Assert.Equal(
             new[]
             {
-                nameof(IExampleServiceGlobalDecorator),
-                nameof(IExampleServiceAuditDecorator),
-                nameof(IExampleServiceTimingDecorator),
-                nameof(IExampleServiceLoggingDecorator),
+                nameof(ExampleServiceGlobalDecorator),
+                nameof(ExampleServiceAuditDecorator),
+                nameof(ExampleServiceTimingDecorator),
+                nameof(ExampleServiceLoggingDecorator),
                 nameof(ExampleService)
             },
             chain);
@@ -127,7 +127,7 @@ public class ExampleServiceTests
     {
         var logger = new TestLogger<IExampleService>();
         var decorated = new TrackingExampleService();
-        var logging = new IExampleServiceLoggingDecorator(decorated, logger);
+        var logging = new ExampleServiceLoggingDecorator(decorated, logger);
 
         logging.Add(1, 2);
 
@@ -140,7 +140,7 @@ public class ExampleServiceTests
     {
         var logger = new TestLogger<IExampleService>();
         var decorated = new TrackingExampleService();
-        var logging = new IExampleServiceLoggingDecorator(decorated, logger);
+        var logging = new ExampleServiceLoggingDecorator(decorated, logger);
 
         var result = logging.Divide(2, 0);
 
@@ -152,7 +152,7 @@ public class ExampleServiceTests
     {
         var logger = new TestLogger<IExampleService>();
         var decorated = new TrackingExampleService { ThrowOnOmg = true };
-        var logging = new IExampleServiceLoggingDecorator(decorated, logger);
+        var logging = new ExampleServiceLoggingDecorator(decorated, logger);
 
         Assert.Throws<InvalidOperationException>(() => logging.OmgException());
 
@@ -164,7 +164,7 @@ public class ExampleServiceTests
     {
         var decorated = new TrackingExampleService();
         var sink = new TestAuditSink();
-        var audit = new IExampleServiceAuditDecorator(decorated, sink);
+        var audit = new ExampleServiceAuditDecorator(decorated, sink);
 
         audit.Add(3, 4);
         audit.PrintMessage("Audit me");
@@ -177,7 +177,7 @@ public class ExampleServiceTests
     public void GlobalDecorator_WritesMessages()
     {
         var decorated = new TrackingExampleService();
-        var global = new IExampleServiceGlobalDecorator(decorated);
+        var global = new ExampleServiceGlobalDecorator(decorated);
         var writer = new StringWriter();
         var original = Console.Out;
         Console.SetOut(writer);
@@ -199,7 +199,7 @@ public class ExampleServiceTests
     public void TimingDecorator_WritesTimingMessages()
     {
         var decorated = new TrackingExampleService();
-        var timing = new IExampleServiceTimingDecorator(decorated);
+        var timing = new ExampleServiceTimingDecorator(decorated);
         var writer = new StringWriter();
         var original = Console.Out;
         Console.SetOut(writer);

--- a/test/Shroud.Generator.Tests/GeneratorTests.cs
+++ b/test/Shroud.Generator.Tests/GeneratorTests.cs
@@ -90,7 +90,13 @@ namespace Test
 		DateTime Now();
 	}
 
-	public partial class ICalculatorLoggingDecorator
+	[Decorate(typeof(TestDecorators.LoggingDecorator<>))]
+	public interface IntrospectionService
+	{
+		void Trace(string message);
+	}
+
+	public partial class CalculatorLoggingDecorator
 	{
 		public int Add(int a, int b)
 		{
@@ -104,21 +110,23 @@ namespace Test
     public void DecoratorGenerator_EmitsExpectedDecorators()
     {
         var runResult = RunGenerator(new DecoratorGenerator(), AttributeSource + DecoratorSource);
-        var loggingSource = GetGeneratedSource(runResult, "ICalculatorLoggingDecorator.g.cs");
-        var auditSource = GetGeneratedSource(runResult, "ICalculatorAuditDecorator.g.cs");
-        var reporterSource = GetGeneratedSource(runResult, "IReporterAuditDecorator.g.cs");
+        var loggingSource = GetGeneratedSource(runResult, "CalculatorLoggingDecorator.g.cs");
+        var auditSource = GetGeneratedSource(runResult, "CalculatorAuditDecorator.g.cs");
+        var reporterSource = GetGeneratedSource(runResult, "ReporterAuditDecorator.g.cs");
+        var introspectionSource = GetGeneratedSource(runResult, "IntrospectionServiceLoggingDecorator.g.cs");
 
-        Assert.Contains("internal partial class ICalculatorLoggingDecorator", loggingSource);
+        Assert.Contains("internal partial class CalculatorLoggingDecorator", loggingSource);
         Assert.DoesNotContain("int Add(", loggingSource);
         Assert.Contains("PreAction(\"Log\"", loggingSource);
         Assert.Contains("PostAction(\"AddAsync\"", loggingSource);
 
-        Assert.Contains("internal partial class ICalculatorAuditDecorator", auditSource);
+        Assert.Contains("internal partial class CalculatorAuditDecorator", auditSource);
         Assert.DoesNotContain("PreAction(\"Add\"", auditSource);
         Assert.Contains("PreAction(\"Log\"", auditSource);
         Assert.Contains("Test.ICalculator decorated", auditSource);
         Assert.Contains("string label", auditSource);
-        Assert.Contains("internal partial class IReporterAuditDecorator", reporterSource);
+        Assert.Contains("internal partial class ReporterAuditDecorator", reporterSource);
+        Assert.Contains("internal partial class IntrospectionServiceLoggingDecorator", introspectionSource);
     }
 
     [Fact]
@@ -127,10 +135,10 @@ namespace Test
         var runResult = RunGenerator(new ShroudExtensionGenerator(), AttributeSource + DecoratorSource);
         var extensionsSource = GetGeneratedSource(runResult, "ShroudExtensions.g.cs");
 
-        var loggingIndex = extensionsSource.IndexOf("ICalculatorLoggingDecorator", StringComparison.Ordinal);
-        var timingIndex = extensionsSource.IndexOf("ICalculatorTimingDecorator", StringComparison.Ordinal);
-        var auditIndex = extensionsSource.IndexOf("ICalculatorAuditDecorator", StringComparison.Ordinal);
-        var reporterIndex = extensionsSource.IndexOf("IReporterAuditDecorator", StringComparison.Ordinal);
+        var loggingIndex = extensionsSource.IndexOf("CalculatorLoggingDecorator", StringComparison.Ordinal);
+        var timingIndex = extensionsSource.IndexOf("CalculatorTimingDecorator", StringComparison.Ordinal);
+        var auditIndex = extensionsSource.IndexOf("CalculatorAuditDecorator", StringComparison.Ordinal);
+        var reporterIndex = extensionsSource.IndexOf("ReporterAuditDecorator", StringComparison.Ordinal);
 
         Assert.True(loggingIndex >= 0, "Logging decorator was not generated.");
         Assert.True(timingIndex > loggingIndex, "Timing decorator should follow logging.");


### PR DESCRIPTION
### Motivation
- Ensure generated decorator class names follow the convention that an interface named with a leading `I` followed by another capital letter loses the leading `I` when composing decorator class names (e.g. `ICalculator` -> `CalculatorLoggingDecorator`).
- Keep decorator naming consistent between the class generator and the extension chain generator so partial implementations and tests match the generated outputs.
- Update examples and docs so consumers understand the new naming convention.

### Description
- Update `DecoratorGenerator` to derive interface names with `CleanInterfaceName` that strips a leading `I` only when it is immediately followed by another uppercase letter (`StripLeadingInterfacePrefix`).
- Update `ShroudExtensionGenerator` to use the same `StripLeadingInterfacePrefix` when composing concrete decorator type names.
- Update unit tests in `test/Shroud.Generator.Tests/GeneratorTests.cs` and `test/Shroud.Example.Tests/ExampleServiceTests.cs` to expect the new generated decorator names and include coverage for an `IntrospectionService` that keeps its leading `I`.
- Rename and update the example partial implementation file to `ExampleServiceLoggingDecorator.Partial.cs` and update `README.md` to document the naming rule and show the matching partial class example.

### Testing
- Updated unit tests in `test/` to reflect the new naming expectations but did not execute them in this environment.
- Attempted to run `dotnet test Shroud.slnx`, but the command failed because `dotnet` is not available in the current environment, so automated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a30e31f98832fba30ccd1f3a04766)