### PR TITLE
Add README/icon to NuGet package and improve package metadata

### DIFF
--- a/src/Shroud.Generator/Shroud.Generator.csproj
+++ b/src/Shroud.Generator/Shroud.Generator.csproj
@@ -12,11 +12,17 @@
 		<Authors>Jacob P. Silvia</Authors>
 		<Product>Shroud</Product>
 		<Description>Decorators for lazy people</Description>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageIcon>icon.png</PackageIcon>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/aethercowboy/Shroud</PackageProjectUrl>
+		<PackageRepositoryUrl>https://github.com/aethercowboy/Shroud</PackageRepositoryUrl>
+		<PackageReleaseNotes>See the project changelog and README for release details and usage examples.</PackageReleaseNotes>
 		<RepositoryUrl>https://github.com/aethercowboy/Shroud</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>shroud;generator;codegeneration;decorator</PackageTags>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -40,6 +46,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" Link="README.md" />
+		<None Include="..\..\icon.png" Pack="true" PackagePath="\" Link="icon.png" />
 		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 		<None Include="$(OutputPath)\$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" Condition="Exists('$(OutputPath)\$(AssemblyName).pdb')" />
 	</ItemGroup>


### PR DESCRIPTION
### Motivation
- Improve the NuGet package presentation so consumers see the project README and icon in package galleries. 
- Provide clearer metadata for repository publishing and discovery when the package is listed on nuget.org. 
- Ensure the package contains the README and icon assets so `PackageReadmeFile` and `PackageIcon` references resolve correctly. 

### Description
- Added `PackageReadmeFile` and `PackageIcon` entries to `src/Shroud.Generator/Shroud.Generator.csproj` to surface `README.md` and `icon.png` in the package. 
- Packed the repository root `README.md` and `icon.png` into the nupkg via linked `<None Include="..\..\README.md" ... />` and `<None Include="..\..\icon.png" ... />` items. 
- Added `PackageRepositoryUrl`, `PackageReleaseNotes`, `PublishRepositoryUrl`, and `PackageRequireLicenseAcceptance` to improve repository publishing behavior and package metadata. 
- Kept existing packaging of analyzer assets intact so the generator assembly and pdb remain included under `analyzers/dotnet/cs`. 

### Testing
- Ran `dotnet build Shroud.slnx` in this environment and it failed because the `dotnet` CLI is not installed here, so no build or test artifacts were produced. 
- No further automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1aaa6af04832fa8f633a56586f6e8)